### PR TITLE
Add load/dump methods to machine and export to aw

### DIFF
--- a/aggregatedata.py
+++ b/aggregatedata.py
@@ -925,48 +925,6 @@ class LabeledData:
             aws.append(aw)
         return aws
 
-    def to_aw(self):
-        """Convert predictions to AvalancheWarnings.
-
-        :return: AvalancheWarning[]
-        """
-        aws = []
-        for name, row in self.pred.iterrows():
-            aw = gf.AvalancheWarning()
-            aw.region_id = int(name[1])
-            aw.valid_from = dt.datetime.combine(dt.date.fromisoformat(name[0]), dt.datetime.min.time())
-            aw.valid_to = dt.datetime.combine(dt.date.fromisoformat(name[0]), dt.datetime.max.time())
-            aw.mountain_weather = gf.MountainWeather()
-            for int_attr, dict in LABEL_GLOBAL.items():
-                for idx, ext_attr in enumerate(dict['ext_attr']):
-                    ext_val = dict['values'][row['CLASS', '', int_attr]][idx]
-                    setattr(aw, ext_attr, ext_val)
-            for p_idx in range(1, int(row['CLASS', '', 'problem_amount']) + 1):
-                p_prefix = f"problem_{p_idx}"
-                p_name = row['CLASS', '', p_prefix]
-                if p_name == "":
-                    break
-                problem = gf.AvalancheWarningProblem()
-                problem.avalanche_problem_id = -p_idx + 4
-                for idx, ext_attr in enumerate(LABEL_PROBLEM_PRIMARY['ext_attr']):
-                    ext_val = LABEL_PROBLEM_PRIMARY['values'][row['CLASS', '', p_prefix]][idx]
-                    setattr(problem, ext_attr, ext_val)
-                for int_attr, dict in LABEL_PROBLEM.items():
-                    for idx, ext_attr in enumerate(dict['ext_attr']):
-                        ext_val = dict['values'][row['CLASS', p_name, int_attr]][idx]
-                        setattr(problem, ext_attr, ext_val)
-                for int_attr, dict in LABEL_PROBLEM_MULTI.items():
-                    ext_attr = dict['ext_attr']
-                    ext_val = row['MULTI', p_name, int_attr]
-                    setattr(problem, ext_attr, ext_val)
-                for int_attr, dict in LABEL_PROBLEM_REAL.items():
-                    ext_attr = dict['ext_attr']
-                    ext_val = row['REAL', p_name, int_attr]
-                    setattr(problem, ext_attr, ext_val)
-                aw.avalanche_problems.append(problem)
-            aws.append(aw)
-        return aws
-
     def copy(self):
         """Deep copy LabeledData.
         :return: copied LabeledData

--- a/machine.py
+++ b/machine.py
@@ -1,9 +1,9 @@
 from aggregatedata import PROBLEMS, _NONE
-import pickle
 import os
 import sys
 import numpy as np
 import pandas
+import dill
 
 old_dir = os.getcwd()
 os.chdir(os.path.dirname(os.path.abspath(__file__)))
@@ -12,6 +12,8 @@ import setenvironment as se
 os.chdir(old_dir)
 
 __author__ = 'arwi'
+
+DILL_VERSION = '1'
 
 class BulletinMachine:
     def __init__(
@@ -239,15 +241,15 @@ class BulletinMachine:
 
 
     def dump(self, identifier):
-        file_name = f'{se.local_storage}model_{identifier}.pickle'
+        file_name = f'{se.local_storage}model_v{DILL_VERSION}_{identifier}.dill'
         with open(file_name, 'wb') as handle:
-            pickle.dump(self, handle, protocol=pickle.HIGHEST_PROTOCOL)
+            dill.dump(self, handle)
 
     @staticmethod
     def load(identifier):
-        file_name = f'{se.local_storage}model_{identifier}.pickle'
+        file_name = f'{se.local_storage}model_v{DILL_VERSION}_{identifier}.dill'
         with open(file_name, 'rb') as handle:
-            return pickle.load(handle)
+            return dill.load(handle)
 
 
 class Error(Exception):


### PR DESCRIPTION
BulletinMachine now has methods `load` and `dump` to persist models on disk.

LabeledData method `to_aw` exports predicted data to a list of AvalancheWarning, used in varsomdata.