### PR TITLE
Enable class_weights on BulletinMachine

### DIFF
--- a/aggregatedata.py
+++ b/aggregatedata.py
@@ -665,7 +665,16 @@ class LabeledData:
             dummies[name] = {"CLASS": {}, "MULTI": {}, "REAL": {}}
             for subprob in df["CLASS"].columns.get_level_values(0).unique():
                 if name == 'label':
-                    dum = pandas.get_dummies(df["CLASS"][subprob], prefix_sep=':')
+                    if subprob == _NONE:
+                        sub_df = df["CLASS"][subprob]
+                    else:
+                        sub_df = df["CLASS"][subprob].loc[
+                            df["CLASS"][_NONE]["problem_1"].eq(subprob).astype(np.int) +
+                            df["CLASS"][_NONE]["problem_2"].eq(subprob).astype(np.int) +
+                            df["CLASS"][_NONE]["problem_3"].eq(subprob).astype(np.int) > 0
+                        ]
+                    col = pandas.get_dummies(sub_df, prefix_sep=':').columns
+                    dum = pandas.DataFrame(pandas.get_dummies(df["CLASS"][subprob], prefix_sep=':'), columns=col)
                     dummies[name]["CLASS"][subprob] = dum
                 else:
                     col = dummies["label"]["CLASS"][subprob].columns

--- a/machine.py
+++ b/machine.py
@@ -5,22 +5,38 @@ import pandas
 __author__ = 'arwi'
 
 class BulletinMachine:
-    def __init__(self, ml_prim_creator, ml_class_creator, ml_multi_creator, ml_real_creator):
+    def __init__(
+            self,
+            ml_prim_creator,
+            ml_class_creator,
+            ml_multi_creator,
+            ml_real_creator,
+            sk_prim_class_weight=None,
+            sk_class_weight=None,
+    ):
         """Facilitates training and prediction of avalanche warnings.
 
-        :param ml_prim_creator:  fn(in_size: Int, out_size: Int) -> classifier: Used to solve primary problems,
-                                 such as "danger_level" and "problem_n". Preferably softmax output.
-        :param ml_class_creator: fn(in_size: Int, out_size: Int) -> classifier: Used to solve secondary problems,
-                                 such as "cause" or "dist". Preferably softmax output.
-        :param ml_multi_creator: fn(in_size: Int, out_size: Int) -> classifier: Used to solve multilabel problems,
-                                 such as "aspect". Must be k-of-n-hot.
-        :param ml_real_creator:  fn(in_size: Int, out_size: Int) -> regressor: Used to solve for real numbers. Must
-                                 support multiple outputs.
+        :param ml_prim_creator:      fn(in_size: Int, out_size: Int) -> classifier: Used to solve primary problems,
+                                     such as "danger_level" and "problem_n". Preferably softmax output.
+        :param ml_class_creator:     fn(in_size: Int, out_size: Int) -> classifier: Used to solve secondary problems,
+                                     such as "cause" or "dist". Preferably softmax output.
+        :param ml_multi_creator:     fn(in_size: Int, out_size: Int) -> classifier: Used to solve multilabel problems,
+                                     such as "aspect". Must be k-of-n-hot.
+        :param ml_real_creator:      fn(in_size: Int, out_size: Int) -> regressor: Used to solve for real numbers. Must
+                                     support multiple outputs.
+        :param sk_prim_class_weight: Class weights for "danger_level", "emergency_warning" and "problem_<n>".
+                                     Either None, "balanced", "balanced_subsample" or dict of type
+                                     {"danger_level": {'4': {0: 2, 1: 2}}}. Only works for sklearn models.
+        :param sk_class_weight:      Class weights for subproblems.
+                                     Either None, "balanced", "balanced_subsample" or dict of type
+                                     {"cause": {'new-snow': {0: 2, 1: 2}}}. Only works for sklearn models.
         """
         self.ml_prim_creator = ml_prim_creator
         self.ml_class_creator = ml_class_creator
         self.ml_multi_creator = ml_multi_creator
         self.ml_real_creator = ml_real_creator
+        self.sk_prim_class_weight = sk_prim_class_weight
+        self.sk_class_weight = sk_class_weight
         self.machines_class = {}
         self.machines_multi = {}
         self.machines_real = {}
@@ -55,9 +71,11 @@ class BulletinMachine:
             if subprob == "":
                 idx = [True] * dummy.shape[0]
                 machine = self.ml_prim_creator
+                class_weight = self.sk_prim_class_weight
             else:
                 idx = np.any(np.char.equal(prob_cols.values.astype("U"), subprob), axis=1)
                 machine = self.ml_class_creator
+                class_weight = self.sk_class_weight
             try:
                 self.machines_class[subprob] = machine(self.X.shape[1:], len(dummy.columns))
             except ValueError:
@@ -68,6 +86,12 @@ class BulletinMachine:
                 try:
                     self.machines_class[subprob].fit(self.X.loc[idx], dummy.loc[idx], epochs=epochs, verbose=verbose)
                 except TypeError:
+                    prepared_weight = prepare_class_weight_(class_weight, dummy)
+                    self.machines_class[subprob] = machine(
+                        self.X.shape[1:],
+                        len(dummy.columns),
+                        class_weight=prepared_weight
+                    )
                     self.machines_class[subprob].fit(self.X.loc[idx], dummy.loc[idx])
         for subprob, dummy in dummies['label']["MULTI"].items():
             idx = np.any(np.char.equal(prob_cols.values.astype("U"), subprob), axis=1)
@@ -219,3 +243,25 @@ class NotFittedError(Error):
 
 class FeatureImportanceMissingError(Error):
     pass
+
+def prepare_class_weight_(class_weight, dummies):
+    if class_weight is None:
+        return None
+    if class_weight == "balanced" or class_weight == "balanced_subsample":
+        return class_weight
+
+    prepared_weight = []
+    for column in dummies.columns:
+        type, problem, attribute, label = column
+        if attribute in class_weight and label in class_weight[attribute]:
+            weight = class_weight[attribute][label]
+            if len(dummies[type, problem, attribute].columns) == 1:
+                prepared_weight.append({1: weight[1]})
+            else:
+                prepared_weight.append(weight)
+        else:
+            if len(dummies[type, problem, attribute].columns) == 1:
+                prepared_weight.append({1: 1})
+            else:
+                prepared_weight.append({0: 1, 1: 1})
+    return prepared_weight

--- a/main.py
+++ b/main.py
@@ -3,8 +3,16 @@ from machine import BulletinMachine
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.linear_model import MultiTaskElasticNet
 
-def classifier_creator(indata, outdata):
-    return RandomForestClassifier(n_estimators=100)
+prim_class_weight = {
+    "danger_level": {'4': {0: 2, 1: 2}},
+}
+
+class_weight = {
+    "cause": {'new-snow': {0: 2, 1: 2}},
+}
+
+def classifier_creator(indata, outdata, class_weight=None):
+    return RandomForestClassifier(n_estimators=100, class_weight=class_weight)
 
 def regressor_creator(indata, outdata):
     return MultiTaskElasticNet()
@@ -24,7 +32,14 @@ f1 = None
 importances = None
 for split_idx, (training_data, testing_data) in enumerate(labeled_data.kfold(5)):
     print(f"Training fold: {split_idx}")
-    bm = BulletinMachine(classifier_creator, classifier_creator, classifier_creator, regressor_creator)
+    bm = BulletinMachine(
+        classifier_creator,
+        classifier_creator,
+        classifier_creator,
+        regressor_creator,
+        sk_prim_class_weight=prim_class_weight,
+        sk_class_weight=class_weight,
+    )
     bm.fit(training_data, epochs=80, verbose=1)
 
     print(f"Testing fold: {split_idx}")


### PR DESCRIPTION
Resolves #7.

BulletinMachine now has two more parameters, `sk_prim_class_weight` and `sk_class_weight`. These are used to set the `class_weight` parameter on sklearn models. Since the exact configuration of the model outputs change depending on the data, this has to be generated internally.

`sk_prim_class_weight` is used for the model calculating the `danger_level`, `emergency_warning`, `problem_1` etc. `sk_class_weight` is applied to the "CLASS" models on the subproblem, i.e. things like `cause` and `dsize`.

Each parameter defaults to `None`. `"balanced"` and `"balanced_subsample"` is passed directly to the model.

However, to fine-tune the weights, a dict can be sent. If we specifically want to change the weight of danger level 4, send a dict as `{"danger_level": {'4': {0: 2, 1: 2}}}` to `sk_prim_class_weight`. This way, each weight can be changed individually.