### PR TITLE
Redefine F1 and RMSE scoring

### DIFF
--- a/avaml/aggregatedata.py
+++ b/avaml/aggregatedata.py
@@ -441,48 +441,54 @@ class LabeledData:
             raise DatasetMissingLabel()
 
         dummies = self.to_dummies()
-        old_settings = np.seterr(divide='raise', invalid='raise')
+        old_settings = np.seterr(divide='ignore', invalid='ignore')
 
-        class_types = []
-        for typ in ["CLASS", "MULTI"]:
-            if typ in dummies["label"].columns.get_level_values(0):
-                class_types.append(typ)
+        df_idx = pd.MultiIndex.from_arrays([[], [], [], []])
+        df = pd.DataFrame(index=df_idx, columns=["f1", "precision", "recall", "rmse"])
 
-        df = None
-        if len(class_types):
-            truth = dummies["label"][class_types]
-            pred = dummies["pred"][class_types]
-            true_pos = np.sum(truth * pred, axis=0)
-            try:
-                prec = true_pos / np.sum(pred, axis=0)
-            except FloatingPointError:
-                prec = pd.Series(index=pred.columns)
-            try:
-                recall = true_pos / np.sum(truth, axis=0)
-            except FloatingPointError:
-                recall = pd.Series(index=pred.columns)
-            try:
-                f1 = 2 * prec * recall / (prec + recall)
-            except FloatingPointError:
-                f1 = pd.Series(index=pred.columns)
+        try:
+            prob_cols = [
+                name.startswith("problem_") for name in self.label.columns.get_level_values(2)
+            ]
+        except KeyError:
+            prob_cols = pd.DataFrame(index=self.label.index)
+        for column, pred_series in dummies["pred"].items():
+            if column[1]:
+                true_idx = self.label.loc[
+                    np.any(np.char.equal(self.label.loc[:, prob_cols].values.astype("U"), column[1]), axis=1)
+                ].index
+                pred_idx = self.pred.loc[
+                    np.any(np.char.equal(self.pred.loc[:, prob_cols].values.astype("U"), column[1]), axis=1)
+                ].index
+                idx = list(set(true_idx.to_list()).intersection(set(pred_idx.to_list())))
+            else:
+                idx = list(set(self.label.index).intersection(set(self.pred.index)))
 
-            df = pd.DataFrame(index=truth.columns, columns=['f1', 'precision', 'recall', 'rmse'])
-            df.iloc[:, :3] = np.array([f1, prec, recall]).transpose()
-            df[['f1', 'precision', 'recall']] = df[['f1', 'precision', 'recall']].fillna(0)
+            if column[0] in ["CLASS", "MULTI"] and column in dummies["label"].columns:
+                truth = dummies["label"][column][idx]
+                pred = pred_series[idx]
+                true_pos = np.sum(truth * pred)
 
-        if "REAL" in dummies["label"].columns.get_level_values(0):
-            truth = dummies["label"][["REAL"]]
-            pred = dummies["pred"][["REAL"]]
-            try:
-                ntruth = (truth - truth.min(axis=0)) / (truth.max(axis=0) - truth.min(axis=0))
-                npred = (pred - pred.min(axis=0)) / (pred.max(axis=0) - pred.min(axis=0))
-                rmse = (np.sqrt(np.sum(np.square(npred - ntruth), axis=0)) / ntruth.shape[0])
-            except Exception:
-                rmse = np.nan
-            rmse = pd.Series(rmse, index=truth.columns)
-            df = rmse if df is None else pd.concat([df, rmse])
-            np.seterr(**old_settings)
+                if not np.sum(truth) or (column[0] == "CLASS" and column[1] and column[3] == "0"):
+                    continue
 
+                prec = true_pos / np.sum(pred) if np.sum(pred) else 0
+                recall = true_pos / np.sum(truth)
+                f1 = 2 * prec * recall / (prec + recall) if prec + recall else 0
+
+                df.loc[column] = pd.Series([f1, prec, recall, np.nan], index=df.columns)
+            elif column[0] in ["REAL"] and column in dummies["label"].columns:
+                truth = dummies["label"][column][idx]
+                pred = pred_series[idx]
+
+                if not len(truth):
+                    continue
+
+                rmse = np.sqrt(np.sum(np.square(pred - truth))) / len(truth)
+
+                df.loc[column] = pd.Series([np.nan, np.nan, np.nan, rmse], index=df.columns)
+
+        np.seterr(**old_settings)
         return df
 
     def to_timeseries(self):


### PR DESCRIPTION
This makes for a more robust measurement of F1, precision, recall
and RMSE.

Now there should never be empty rows in the F1 DataFrame as it has
been before. Instead these rows are simply omitted.

The largest difference is how scores for features of avalanche
problems are calculated though. Earlier, the scores were computed
on the whole column. That meant that the scores were greatly
influenced by how accurate the avalanche problem columns
"problem_1", "problem_2" and "problem_3" were. Now the scores for
these attributes are only computed for rows where the given
avalanche problem exists in both the label and in the prediction.

This has some implications. We will get a more representative
score of how the model performs when an avalanche problem is
correctly predicted. However, we will have no indication of
how the internal attributes perform when the avalanche problem
is not predicted. This shouldn't be a problem, since there's not
an obvious way to reason about such data. The previous calculation
didn't give any indication about this either, as it was mostly a
function of the primary avalanche problem prediction.

When combining F1 DataFrames in a kfold loop, missing columns must
be taken care of, therefore the demos now have a more complex
handling of this.