### PR TITLE
Add distance measurement between forecasts

### DIFF
--- a/avaml/score/__init__.py
+++ b/avaml/score/__init__.py
@@ -102,15 +102,16 @@ class Score:
             p_score.loc[idx] = np.array([problem_score] + spatial_diffs)
         weights = np.array([1, 1, 1])
         maxdist = np.power(weights, 2).sum()
+        score = np.power(
+            pd.concat([diff.iloc[:, :2], p_score[[("", "problem_score")]]], axis=1).astype(np.float) * weights,
+            2
+        ).sum(axis=1)
         score = pd.DataFrame(
-            np.power(
-                pd.concat([diff.iloc[:, :2], p_score[[("", "p_score")]]], axis=1).astype(np.float) * weights,
-                2
-            ).sum(axis=1),
+            pd.concat([score / maxdist, np.sqrt(score) / np.sqrt(maxdist)], axis=1).values,
             index=diff.index,
-            columns=pd.MultiIndex.from_tuples([(_NONE, "score")])
+            columns=pd.MultiIndex.from_tuples([(_NONE, "score"), (_NONE, "distance")])
         )
-        return pd.concat([score / maxdist, p_score, diff], axis=1).sort_index(axis=1)
+        return pd.concat([score, p_score, diff], axis=1).sort_index(axis=1)
 
 def dist(score1, score2):
     def distvec(vec1, vec2):

--- a/avaml/score/__init__.py
+++ b/avaml/score/__init__.py
@@ -93,13 +93,13 @@ class Score:
     def calc(self):
         diff_cols = [not re.match(r"^(lev_)|(aspect)", col) for col in self.label_vectors.columns.get_level_values(1)]
         diff = self.pred_vectors.loc[:, diff_cols] - self.label_vectors.loc[:, diff_cols]
-        p_score_cols = pd.MultiIndex.from_tuples([(_NONE, "p_score")]).append(
-            pd.MultiIndex.from_product([[f"problem_{n}" for n in range(1, 4)], ["overlap"]])
+        p_score_cols = pd.MultiIndex.from_tuples([(_NONE, "problem_score")]).append(
+            pd.MultiIndex.from_product([[f"problem_{n}" for n in range(1, 4)], ["spatial_diff"]])
         )
         p_score = pd.DataFrame(index=diff.index, columns=p_score_cols)
         for idx, series in self.label_vectors.iterrows():
-            problem_score, overlaps = dist(series, self.pred_vectors.loc[idx])
-            p_score.loc[idx] = np.array([problem_score] + overlaps)
+            problem_score, spatial_diffs = dist(series, self.pred_vectors.loc[idx])
+            p_score.loc[idx] = np.array([problem_score] + spatial_diffs)
         weights = np.array([1, 1, 1])
         maxdist = np.power(weights, 2).sum()
         score = pd.DataFrame(
@@ -114,18 +114,18 @@ class Score:
 
 def dist(score1, score2):
     def distvec(vec1, vec2):
-        overlap = calc_overlap(vec1, vec2)
+        spatial_diff = 1 - calc_overlap(vec1, vec2)
 
         # Distance to the null forecast is the distance to the plane freq = 0.
         if not vec1["freq"]:
-            return vec2["freq"], overlap
+            return vec2["freq"], spatial_diff
         if not vec2["freq"]:
-            return vec1["freq"], overlap
+            return vec1["freq"], spatial_diff
 
-        diff = np.append(vec1.iloc[:3] - vec2.iloc[:3], [1 - overlap])
+        diff = np.append(vec1.iloc[:3] - vec2.iloc[:3], [spatial_diff])
         # With two valid forecasts, compute a weighted euclidean norm.
         norm = np.linalg.norm((diff) * np.array([1, 1, 1, 0.5]))
-        return norm, overlap
+        return norm, spatial_diff
 
     def mindist(vec1, vecs):
         mindist = None
@@ -139,13 +139,13 @@ def dist(score1, score2):
     distance = 0
     prob_cols = [f"problem_{n}" for n in range(1, 4)]
     weights = [3, 2, 1]
-    overlaps = []
+    spatial_diffs = []
     for prob_n, weight in zip(prob_cols, weights):
-        norm, overlap = distvec(score1[prob_n], score2[prob_n])
+        norm, spatial_diff = distvec(score1[prob_n], score2[prob_n])
         distance += norm * weight
         dist_1 = mindist(score1[prob_n], [score2[prob_m] for prob_m in prob_cols])
         dist_2 = mindist(score2[prob_n], [score1[prob_m] for prob_m in prob_cols])
         distance += (dist_1 + dist_2) * weight / 2
-        overlaps.append(overlap)
+        spatial_diffs.append(spatial_diff)
 
-    return distance / (2 * maxdist * sum(weights)), overlaps
+    return distance / (2 * maxdist * sum(weights)), spatial_diffs

--- a/avaml/score/__init__.py
+++ b/avaml/score/__init__.py
@@ -1,0 +1,154 @@
+from functools import reduce
+import re
+import copy
+import datetime as dt
+
+import numpy as np
+import pandas as pd
+from sklearn.preprocessing import MinMaxScaler
+from sklearn.model_selection import StratifiedKFold, KFold
+
+from avaml import Error, varsomdata, setenvironment as se, _NONE, CSV_VERSION, REGIONS, merge
+from avaml.aggregatedata import DatasetMissingLabel
+from avaml.download import _get_varsom_obs, _get_weather_obs, _get_regobs_obs, REG_ENG, PROBLEMS
+from avaml.score.overlap import calc_overlap
+from varsomdata import getforecastapi as gf
+from varsomdata import getmisc as gm
+
+__author__ = 'arwi'
+
+VECTOR_WETNESS_LOOSE = {
+    _NONE: (0, 0),
+    "new-loose": (0, 1),
+    "wet-loose": (1, 1),
+    "new-slab": (0, 0.4),
+    "drift-slab": (0, 0.2),
+    "pwl-slab": (0, 0),
+    "wet-slab": (1, 0),
+    "glide": (0.8, 0),
+}
+
+VECTOR_FREQ = {
+    "dsize": {
+        _NONE: 0,
+        '0': 0,
+        '1': 0.2,
+        '2': 0.4,
+        '3': 0.6,
+        '4': 0.8,
+        '5': 1,
+    },
+    "dist": {
+        _NONE: 0,
+        '0': 0,
+        '1': 0.25,
+        '2': 0.5,
+        '3': 0.75,
+        '4': 1,
+    },
+    "trig": {
+        _NONE: 0,
+        '0': 0,
+        '10': 1 / 3,
+        '21': 2 / 3,
+        '22': 1,
+    },
+    "prob": {
+        _NONE: 0,
+        '0': 0,
+        '2': 1 / 3,
+        '3': 2 / 3,
+        '5': 1,
+    },
+}
+
+class Score:
+    def __init__(self, labeled_data):
+        def to_vec(df):
+            level_2 = ["wet", "loose", "freq", "lev_max", "lev_min", "lev_fill", "aspect"]
+            columns = pd.MultiIndex.from_product([[_NONE], ["danger_level", "emergency_warning"]]).append(
+                pd.MultiIndex.from_product([[f"problem_{n}" for n in range(1, 4)], level_2])
+            )
+            vectors = pd.DataFrame(index=df.index, columns=columns)
+            vectors[(_NONE, "danger_level")] = df[("CLASS", _NONE, "danger_level")].astype(np.int) / 5
+            vectors[(_NONE, "emergency_warning")] = (
+                    df[("CLASS", _NONE, "emergency_warning")] == "Naturlig utløste skred"
+            ).astype(np.int)
+            for idx, row in df.iterrows():
+                for prob_n in [f"problem_{n}" for n in range(1, 4)]:
+                    problem = row["CLASS", _NONE, prob_n]
+                    if problem == _NONE:
+                        vectors.loc[idx, prob_n] = [0, 0, 0, 0, 0, 2, "00000000"]
+                    else:
+                        p_class = row["CLASS", problem]
+                        p_real = row["REAL", problem]
+                        wet = VECTOR_WETNESS_LOOSE[problem][0]
+                        loose = VECTOR_WETNESS_LOOSE[problem][1]
+                        freq = reduce(lambda x, y: x * VECTOR_FREQ[y][p_class[y]], VECTOR_FREQ.keys(), 1)
+                        lev_max = float(p_real["lev_max"]) if p_real["lev_max"] else 0.0
+                        lev_min = float(p_real["lev_min"]) if p_real["lev_min"] else 0.0
+                        lev_fill = int(p_class["lev_fill"]) if p_class["lev_fill"] else 0
+                        aspect = row["MULTI", problem, "aspect"]
+                        vectors.loc[idx, prob_n] = [wet, loose, freq, lev_max, lev_min, lev_fill, aspect]
+            return vectors
+
+        if labeled_data.label is None or labeled_data.pred is None:
+            raise DatasetMissingLabel()
+        self.label_vectors = to_vec(labeled_data.label)
+        self.pred_vectors = to_vec(labeled_data.pred)
+
+    def calc(self):
+        diff_cols = [not re.match(r"^(lev_)|(aspect)", col) for col in self.label_vectors.columns.get_level_values(1)]
+        diff = self.pred_vectors.loc[:, diff_cols] - self.label_vectors.loc[:, diff_cols]
+        p_score_cols = pd.MultiIndex.from_tuples([(_NONE, "p_score")]).append(
+            pd.MultiIndex.from_product([[f"problem_{n}" for n in range(1, 4)], ["overlap"]])
+        )
+        p_score = pd.DataFrame(index=diff.index, columns=p_score_cols)
+        for idx, series in self.label_vectors.iterrows():
+            problem_score, overlaps = dist(series, self.pred_vectors.loc[idx])
+            p_score.loc[idx] = np.array([problem_score] + overlaps)
+        weights = np.array([1, 1, 1])
+        maxdist = np.linalg.norm(weights)
+        score = pd.DataFrame(np.linalg.norm(
+            pd.concat([diff.iloc[:, :2], p_score[[("", "p_score")]]], axis=1).astype(np.float) * weights,
+            axis=1
+        ), index=diff.index, columns=pd.MultiIndex.from_tuples([(_NONE, "score")]))
+        return pd.concat([score / maxdist, p_score, diff], axis=1)
+
+def dist(score1, score2):
+    def distvec(vec1, vec2):
+        overlap = calc_overlap(vec1, vec2)
+
+        # Distance to the null forecast is the distance to the plane freq = 0.
+        if not vec1["freq"]:
+            return vec2["freq"], overlap
+        if not vec2["freq"]:
+            return vec1["freq"], overlap
+
+        diff = np.append(vec1.iloc[:3] - vec2.iloc[:3], [1 - overlap])
+        # With two valid forecasts, compute a weighted euclidean norm.
+        norm = np.linalg.norm((diff) * np.array([1, 1, 1, 0.5]))
+        return norm, overlap
+
+    def mindist(vec1, vecs):
+        mindist = None
+        for vec2 in vecs:
+            dist, _ = distvec(vec1, vec2)
+            if dist > 0 and (mindist is None or dist < mindist):
+                mindist = dist
+        return mindist if mindist is not None else 0
+
+    maxdist = np.linalg.norm(np.array([1, 1, 1, 0.5]))
+    distance = 0
+    prob_cols = [f"problem_{n}" for n in range(1, 4)]
+    weights = [3, 2, 1]
+    overlaps = []
+    for prob_n, weight in zip(prob_cols, weights):
+        norm, overlap = distvec(score1[prob_n], score2[prob_n])
+        distance += norm * weight
+        dist_1 = mindist(score1[prob_n], [score2[prob_m] for prob_m in prob_cols])
+        dist_2 = mindist(score2[prob_n], [score1[prob_m] for prob_m in prob_cols])
+        distance += (dist_1 + dist_2) * weight / 2
+        overlaps.append(overlap)
+
+    return distance / (2 * maxdist * sum(weights)), overlaps

--- a/avaml/score/__init__.py
+++ b/avaml/score/__init__.py
@@ -101,12 +101,16 @@ class Score:
             problem_score, overlaps = dist(series, self.pred_vectors.loc[idx])
             p_score.loc[idx] = np.array([problem_score] + overlaps)
         weights = np.array([1, 1, 1])
-        maxdist = np.linalg.norm(weights)
-        score = pd.DataFrame(np.linalg.norm(
-            pd.concat([diff.iloc[:, :2], p_score[[("", "p_score")]]], axis=1).astype(np.float) * weights,
-            axis=1
-        ), index=diff.index, columns=pd.MultiIndex.from_tuples([(_NONE, "score")]))
-        return pd.concat([score / maxdist, p_score, diff], axis=1)
+        maxdist = np.power(weights, 2).sum()
+        score = pd.DataFrame(
+            np.power(
+                pd.concat([diff.iloc[:, :2], p_score[[("", "p_score")]]], axis=1).astype(np.float) * weights,
+                2
+            ).sum(axis=1),
+            index=diff.index,
+            columns=pd.MultiIndex.from_tuples([(_NONE, "score")])
+        )
+        return pd.concat([score / maxdist, p_score, diff], axis=1).sort_index(axis=1)
 
 def dist(score1, score2):
     def distvec(vec1, vec2):

--- a/avaml/score/__init__.py
+++ b/avaml/score/__init__.py
@@ -59,12 +59,12 @@ class Score:
     def __init__(self, labeled_data):
         def to_vec(df):
             level_2 = ["wet", "loose", "freq", "lev_max", "lev_min", "lev_fill", "aspect"]
-            columns = pd.MultiIndex.from_product([[_NONE], ["danger_level", "emergency_warning"]]).append(
+            columns = pd.MultiIndex.from_product([["global"], ["danger_level", "emergency_warning"]]).append(
                 pd.MultiIndex.from_product([[f"problem_{n}" for n in range(1, 4)], level_2])
             )
             vectors = pd.DataFrame(index=df.index, columns=columns)
-            vectors[(_NONE, "danger_level")] = df[("CLASS", _NONE, "danger_level")].astype(np.int) / 5
-            vectors[(_NONE, "emergency_warning")] = (
+            vectors[("global", "danger_level")] = df[("CLASS", _NONE, "danger_level")].astype(np.int) / 5
+            vectors[("global", "emergency_warning")] = (
                     df[("CLASS", _NONE, "emergency_warning")] == "Naturlig utløste skred"
             ).astype(np.int)
             for idx, row in df.iterrows():

--- a/avaml/score/__init__.py
+++ b/avaml/score/__init__.py
@@ -1,19 +1,12 @@
 from functools import reduce
 import re
-import copy
-import datetime as dt
 
 import numpy as np
 import pandas as pd
-from sklearn.preprocessing import MinMaxScaler
-from sklearn.model_selection import StratifiedKFold, KFold
 
-from avaml import Error, varsomdata, setenvironment as se, _NONE, CSV_VERSION, REGIONS, merge
+from avaml import _NONE
 from avaml.aggregatedata import DatasetMissingLabel
-from avaml.download import _get_varsom_obs, _get_weather_obs, _get_regobs_obs, REG_ENG, PROBLEMS
 from avaml.score.overlap import calc_overlap
-from varsomdata import getforecastapi as gf
-from varsomdata import getmisc as gm
 
 __author__ = 'arwi'
 

--- a/avaml/score/overlap.py
+++ b/avaml/score/overlap.py
@@ -1,0 +1,77 @@
+MAX = 2500
+
+def calc_overlap(vec1, vec2):
+    aspect = aspect_overlap(vec1["aspect"], vec2["aspect"])
+    height_args = vec1[3:6].tolist() + vec2[3:6].tolist()
+    height = height_overlap(*height_args)
+    return aspect * height
+
+def aspect_overlap(aspect1, aspect2):
+    if aspect1 == "" or aspect2 == "":
+        return 0
+    aspect1 = int(aspect1.zfill(8), base=2)
+    aspect2 = int(aspect2.zfill(8), base=2)
+    return bin(aspect1 ^ aspect2).count("1") / 8
+
+def height_overlap(lev1_max, lev1_min, lev1_fill, lev2_max, lev2_min, lev2_fill):
+    [(lev1_max, lev1_min, lev1_fill), (lev2_max, lev2_min, lev2_fill)] = sorted(
+        [(lev1_max, lev1_min, lev1_fill), (lev2_max, lev2_min, lev2_fill)],
+        key=lambda x: x[2]
+    )
+    if not lev1_fill or not lev2_fill:
+        return 0
+    match = {
+        (1, 1): (top_top, bottom_bottom),
+        (1, 2): (top_bottom, top_bottom),
+        (1, 3): (top_sandwich, bottom_middle),
+        (1, 4): (top_middle, bottom_sandwich),
+        (2, 2): (bottom_bottom, top_top),
+        (2, 3): (bottom_sandwich, top_middle),
+        (2, 4): (bottom_middle, top_sandwich),
+        (3, 3): (sandwich_sandwich, middle_middle),
+        (3, 4): (sandwich_middle, sandwich_middle),
+        (4, 4): (middle_middle, sandwich_sandwich),
+    }
+    func, inverse_func = match[(lev1_fill, lev2_fill)]
+    verse = func(lev1_max, lev1_min, lev2_max, lev2_min)
+    inverse = inverse_func(lev2_max, lev2_min, lev1_max, lev1_min)
+    return verse + inverse
+
+
+def top_top(top1, _top1, top2, _top2):
+    return middle_middle(MAX, top1, MAX, top2)
+
+def top_bottom(top, _top, bottom, _bottom):
+    return middle_middle(MAX, top, bottom, 0)
+
+def top_sandwich(top, _top, sand_max, sand_min):
+    return 1 - max(top, sand_max) / MAX + top_bottom(top, None, sand_min, None)
+
+def top_middle(top, _top, middle_max, middle_min):
+    return middle_middle(MAX, top, middle_max, middle_min)
+
+def bottom_bottom(bottom1, _bottom1, bottom2, _bottom2):
+    return middle_middle(bottom1, 0, bottom2, 0)
+
+def bottom_sandwich(bottom, _bottom, sand_max, sand_min):
+    return top_bottom(sand_max, None, bottom, None) + min(sand_min, bottom) / MAX
+
+def bottom_middle(bottom, _bottom, middle_max, middle_min):
+    return middle_middle(bottom, 0, middle_max, middle_min)
+
+def sandwich_sandwich(sand1_max, sand1_min, sand2_max, sand2_min):
+    top = top_sandwich(sand1_max, None, sand2_max, sand2_min)
+    bottom = bottom_sandwich(sand1_min, None, sand2_max, sand2_min)
+    return top + bottom
+
+def sandwich_middle(sand_max, sand_min, middle_max, middle_min):
+    top = middle_middle(MAX, sand_max, middle_max, middle_min)
+    bottom = middle_middle(sand_min, 0, middle_max, middle_min)
+    return top + bottom
+
+def middle_middle(middle1_max, middle1_min, middle2_max, middle2_min):
+    srt = sorted([middle1_max, middle1_min, middle2_max, middle2_min])
+    if (middle1_max < middle2_min) != (middle1_min < middle2_max):
+        return (srt[2] - srt[1]) / MAX
+    else:
+        return 0

--- a/avaml/score/overlap.py
+++ b/avaml/score/overlap.py
@@ -1,3 +1,5 @@
+import math
+
 MAX = 2500
 
 def calc_overlap(vec1, vec2):
@@ -7,19 +9,19 @@ def calc_overlap(vec1, vec2):
     return aspect * height
 
 def aspect_overlap(aspect1, aspect2):
-    if aspect1 == "" or aspect2 == "":
-        return 0
-    aspect1 = int(aspect1.zfill(8), base=2)
-    aspect2 = int(aspect2.zfill(8), base=2)
-    return bin(aspect1 ^ aspect2).count("1") / 8
+    aspect1 = int(aspect1, base=2) if aspect1 and not math.isnan(int(aspect1)) else 0
+    aspect2 = int(aspect2, base=2) if aspect2 and not math.isnan(int(aspect2)) else 0
+    return (8 - bin(aspect1 ^ aspect2).count("1")) / 8
 
 def height_overlap(lev1_max, lev1_min, lev1_fill, lev2_max, lev2_min, lev2_fill):
     [(lev1_max, lev1_min, lev1_fill), (lev2_max, lev2_min, lev2_fill)] = sorted(
         [(lev1_max, lev1_min, lev1_fill), (lev2_max, lev2_min, lev2_fill)],
         key=lambda x: x[2]
     )
-    if not lev1_fill or not lev2_fill:
-        return 0
+    if not lev1_fill or math.isnan(lev1_fill):
+        return height_overlap(0, 0, 1, lev2_max, lev2_min, lev2_fill)
+    if not lev1_fill or math.isnan(lev2_fill):
+        return height_overlap(lev1_max, lev1_min, lev1_fill, 0, 0, 1)
     match = {
         (1, 1): (top_top, bottom_bottom),
         (1, 2): (top_bottom, top_bottom),


### PR DESCRIPTION
This is a way to compare avalanche bulletins. It is a kind of
distance measurement. It is commutative but does not fulfill the
triangle inequality, as the null forecast is defined as a plane.

It works in three stages. First it measures the difference between
avalanche problems. Then it measures the difference between ordered
lists of avalanche problems. This is called the p_score. The last
stage is to compare the tuple
(danger_level, emergency_warning, p_score).

It is currently rather unbalanced. This will be adjusted later.